### PR TITLE
New alpha-mapping firebase project and environment

### DIFF
--- a/src/Firebase/firebase.js
+++ b/src/Firebase/firebase.js
@@ -4,7 +4,6 @@ import { getAuth } from "firebase/auth";
 const {
   REACT_APP_API_KEY,
   REACT_APP_AUTH_DOMAIN,
-  REACT_APP_DATABASE_URL,
   REACT_APP_PROJECT_ID,
   REACT_APP_STORAGE_BUCKET,
   REACT_APP_MESSAGING_SENDER_ID,
@@ -15,7 +14,6 @@ const {
 const firebaseConfig = {
   apiKey: REACT_APP_API_KEY,
   authDomain: REACT_APP_AUTH_DOMAIN,
-  databaseURL: REACT_APP_DATABASE_URL,
   projectId: REACT_APP_PROJECT_ID,
   storageBucket: REACT_APP_STORAGE_BUCKET,
   messagingSenderId: REACT_APP_MESSAGING_SENDER_ID,


### PR DESCRIPTION
Remove a variable on the firebase config because it does not appear with the new config of firebase. We create a new firebase project to avoid the leak of the API key, like this, we have new config and the leaked envrionment variables are now deprecated.